### PR TITLE
Update to 2012 Update 4, and install both x86 and x64 on 64bit machines

### DIFF
--- a/vcredist2012/tools/chocolateyInstall.ps1
+++ b/vcredist2012/tools/chocolateyInstall.ps1
@@ -1,5 +1,22 @@
-﻿Install-ChocolateyPackage -packageName $packageName -fileType 'exe' -silentArgs '/Q' `
-                    -url 'http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU3/vcredist_x86.exe' `
-                    -url64bit 'http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU3/vcredist_x64.exe'
+﻿$packageName = 'vcredist2012'
+$installerType = 'EXE'
+$32BitUrl = 'http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe'
+$64BitUrl = 'http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe'
+$silentArgs = '/Q'
+$validExitCodes = @(0,3010)
 
+try {
+	#first install vcredist targetting actual CPU architecture
+	Install-ChocolateyPackage "$packageName" "$installerType" "$silentArgs" "$32BitUrl" "$64BitUrl" -validExitCodes $validExitCodes
 
+	$is64bit = $is64bit = Get-ProcessorBits 64;
+	if($is64bit) {
+		#in case of x64 also install x86 vcredist
+		Install-ChocolateyPackage "$packageName" "$installerType" "$silentArgs" "$32BitUrl" -validExitCodes $validExitCodes
+	}
+
+	Write-ChocolateySuccess 'vcredist2010'
+} catch {
+	Write-ChocolateyFailure 'vcredist2010' "$($_.Exception.Message)"
+	throw 
+}

--- a/vcredist2012/vcredist2012.nuspec
+++ b/vcredist2012/vcredist2012.nuspec
@@ -2,19 +2,23 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>vcredist2012</id>
-        <version>11.0.2012.3</version>
+        <version>11.0.61030</version>
         <title>Microsoft Visual C++ 2012 Redistributable Package</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
-        <licenseUrl>http://www.microsoft.com/about/legal/en/us/IntellectualProperty/Copyright/Default.aspx</licenseUrl>
-        <projectUrl>http://www.microsoft.com/download/en/confirmation.aspx?id=8328</projectUrl>
+        <licenseUrl>http://msdn.microsoft.com/en-US/vstudio/hh857605</licenseUrl>
+        <projectUrl>http://www.microsoft.com/en-US/download/details.aspx?id=30679</projectUrl>
         <iconUrl>https://www.microsoft.com/global/ImageStore/PublishingImages/logos/56x56/microsoft_logo_56x56.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>The Visual C++ Redistributable Packages install runtime components that are required to run C++ applications built with Visual Studio 2012.</description>
-        <summary>The Visual C++ Redistributable Packages install runtime components that are required to run C++ applications built with Visual Studio 2012.</summary>
+        <summary>
+            The Visual C++ Redistributable Packages install runtime components that are required to run C++ applications built with Visual Studio 2012.
+
+            NOTE: This will install both the x86 and x64 versions on a 64bit OS.  the x86 version will only be installed on 32bit OS's
+        </summary>
         <releaseNotes />
-        <copyright>http://www.microsoft.com/about/legal/en/us/IntellectualProperty/Copyright/Default.aspx</copyright>
-        <tags>visual c++ redistributable 2008 studio</tags>
+        <copyright>http://www.microsoft.com/en-US/legal/Copyright/Default.aspx</copyright>
+        <tags>visual c++ cpp redistributable 2012 studio</tags>
     </metadata>
     <files>
         <file src="tools\chocolateyInstall.ps1" target="tools\chocolateyInstall.ps1" />


### PR DESCRIPTION
Hi Mark,
updated this package to the latest vcredist2012 available. Also changed the install script to install both editions on 64 bit Windows (similar to your vcredist2010 package), and updated nuspec links.
Nowdays moderation is enabled on chocolatey.org, which means that the .ps1 file has to follow certain rules. I have adapted it already.
