### PR TITLE
Update vcredist2010 package to newer version to 10.0.40219.325

### DIFF
--- a/vcredist2010/tools/chocolateyInstall.ps1
+++ b/vcredist2010/tools/chocolateyInstall.ps1
@@ -1,14 +1,12 @@
-﻿try { 
-  $processor = Get-WmiObject Win32_Processor
-  $is64bit = $processor.AddressWidth -eq 64
-  Install-ChocolateyPackage 'vcredist2010' 'exe' '/Q' 'http://download.microsoft.com/download/C/6/D/C6D0FD4E-9E53-4897-9B91-836EBA2AACD3/vcredist_x86.exe'
-  if($is64bit) {
-  	Install-ChocolateyPackage 'vcredist2010_x64' 'exe' '/Q' 'http://download.microsoft.com/download/A/8/0/A80747C3-41BD-45DF-B505-E9710D2744E0/vcredist_x64.exe'
-  }
+﻿$processor = Get-WmiObject Win32_Processor
+$is64bit = $processor.AddressWidth -eq 64
+Install-ChocolateyPackage 'vcredist2010' 'exe' '/Q' 'https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x86.exe' `
+            -checksum 67313B3D1BC86E83091E8DE22981F14968F1A7FB12EB7AD467754C40CD94CC3D `
+            -checksumType sha256
 
-  # the following is all part of error handling
-  Write-ChocolateySuccess 'vcredist2010'
-} catch {
-  Write-ChocolateyFailure 'vcredist2010' "$($_.Exception.Message)"
-  throw 
+                
+if($is64bit) {
+    Install-ChocolateyPackage 'vcredist2010_x64' 'exe' '/Q' 'https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x64.exe' `
+            -checksum64 CC7EC044218C72A9A15FCA2363BAED8FC51095EE3B2A7593476771F9EBA3D223 `
+            -checksumType64 sha256
 }

--- a/vcredist2010/vcredist2010.nuspec
+++ b/vcredist2010/vcredist2010.nuspec
@@ -1,20 +1,22 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
-    <version>10.0.40219.1</version>
+    <version>10.0.40219.3</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <licenseUrl>http://www.microsoft.com/about/legal/en/us/IntellectualProperty/Copyright/Default.aspx</licenseUrl>
-    <projectUrl>http://www.microsoft.com/download/en/confirmation.aspx?id=8328</projectUrl>
+    <projectUrl>https://www.microsoft.com/en-us/download/details.aspx?id=26999</projectUrl>
     <id>vcredist2010</id>
     <title>Microsoft Visual C++ 2010 Redistributable Package</title>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The Microsoft Visual C++ 2010 SP1 Redistributable Package (x6 &amp; x864) installs runtime components of Visual C++ Libraries required to run 64-bit and 32-bit applications developed with Visual C++ SP1 on a computer that does not have Visual C++ 2010 SP1 installed. 
+    <description>
+      Microsoft Visual C++ 2010 Service Pack 1 Redistributable Package MFC Security Update (x86 &amp; x64) installs runtime components of Visual C++ Libraries required to run 64-bit and 32-bit applications developed with Visual C++ SP1 on a computer that does not have Visual C++ 2010 SP1 installed.
 
-NOTE: This will install both the x86 and x64 versions on a 64bit OS.  the x86 version will only be installed on 32bit OS's</description>
+      NOTE: This will install both the x86 and x64 versions on a 64bit OS.  the x86 version will only be installed on 32bit OS's
+    </description>
     <summary>This package installs runtime components of C Runtime (CRT), Standard C++, ATL, MFC, OpenMP and MSDIA libraries. For libraries that support side-by-side deployment model (CRT, SCL, ATL, MFC, OpenMP) t</summary>
-    <releaseNotes />
+    <releaseNotes>Updated to version with MFC Security Update</releaseNotes>
     <copyright>http://www.microsoft.com/about/legal/en/us/IntellectualProperty/Copyright/Default.aspx</copyright>
-    <tags>visual c++ redistributable 2008 studio</tags>
+    <tags>visual c++ redistributable 2010 studio</tags>
   </metadata>
 </package>


### PR DESCRIPTION
Microsoft has newer version of the Microsoft Visual C++ 2010 Service Pack 1 Redistributable Package that contains a MFC security update that should be preferred over the older package. I have updated the chocolatey package to install new version. I have also removed the deprecated result reporting that aren't needed in chocolatey packages anymore (Chocolatey is issuing warnings otherwise).

Can you please take it an update the chocolatey.org repository? Thanks